### PR TITLE
Simplify handling of primitive slices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Daniel Cohen
+Copyright (c) 2023-2025 Daniel Cohen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/field_map.go
+++ b/field_map.go
@@ -72,7 +72,8 @@ func getFieldMapHelper(vType reflect.Type, path []string, idxPath []int, visited
 		}
 
 		scannable := structField.Type.Implements(reflect.TypeOf(new(sql.Scanner)).Elem())
-		isFlat := slices.Contains(extraOptions, dbTagOptionFlat)
+		isFlat := slices.Contains(extraOptions, dbTagOptionFlat) ||
+			(structField.Type.Kind() == reflect.Slice && structField.Type.Elem().Kind() != reflect.Struct)
 		canRecurse := !scannable && !isFlat && !isBuiltinStruct(structField.Type)
 
 		if canRecurse {

--- a/scanner.go
+++ b/scanner.go
@@ -6,5 +6,3 @@ package scansion
 type Scanner interface {
 	Scan(v any) error
 }
-
-type scannerFunc func(i ...any) error

--- a/shared.go
+++ b/shared.go
@@ -36,6 +36,10 @@ func buildHelper(fieldMap fieldMapType, path []string, target reflect.Value) err
 		childPath := strings.Join(newPath, ".")
 		childField := fieldMap[childPath]
 
+		if childField.Flat && childField.ScannedValue.IsValid() {
+			target.FieldByIndex(childField.StructIdx).Set(childField.ScannedValue)
+		}
+
 		childType := childField.Type
 		if childType.Kind() == reflect.Pointer {
 			childType = childType.Elem()
@@ -127,7 +131,7 @@ func sliceMerge(slice, elem reflect.Value) error {
 		for fieldIdx := 0; fieldIdx < elem.NumField(); fieldIdx++ {
 			sliceValField := sliceVal.Field(fieldIdx)
 			elemField := elem.Field(fieldIdx)
-			if elemField.Kind() == reflect.Slice {
+			if elemField.Kind() == reflect.Slice && elemField.Type().Elem().Kind() == reflect.Struct {
 				for elemIdx := 0; elemIdx < elemField.Len(); elemIdx++ {
 					if err := sliceMerge(sliceValField, elemField.Index(elemIdx)); err != nil {
 						return err


### PR DESCRIPTION
Primitive slices (slices of non-structs) should always be treated as flat.